### PR TITLE
change artifactId value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>%CUSTOM_PLUGIN_PROJECT_NAMESPACE%</groupId>
-    <artifactId>%CUSTOM_PLUGIN_PROJECT_NAME%</artifactId>
+    <artifactId>%CUSTOM_PLUGIN_SERVICE_NAME%</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 


### PR DESCRIPTION
I've change the interpolation of the artifactId value from `%CUSTOM_PLUGIN_PROJECT_NAME%` to `%CUSTOM_PLUGIN_SERVICE_NAME%` because artifactId must be lowercase and `%CUSTOM_PLUGIN_PROJECT_NAME%`  could be uppercase.
[maven documentation](http://maven.apache.org/guides/mini/guide-naming-conventions.html)